### PR TITLE
fix typo in swagger.yml

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -412,7 +412,6 @@ paths:
         description: 'Project node id'
         required: true
         type: string
-      parameters:
       - name: resources
         in: query
         description: 'Type of resource requested'


### PR DESCRIPTION
typo meant that project node id didn't show up as a field in the swagger ui. 