### PR TITLE
Add 404 and more logging

### DIFF
--- a/app/controllers/GenericExplorerController.scala
+++ b/app/controllers/GenericExplorerController.scala
@@ -102,7 +102,7 @@ class GenericExplorerController @Inject() (
         logger.debug( "Returning metadata for node with id" + id )
         Ok( Json.toJson( vertex )( PersistedVertexFormat ) )
       case None =>
-        logger.debug( "Node with id " + id + " does not exist or does not have any metadata" )
+        logger.debug( "Node with id " + id + " does not exist" )
         NotFound
     }
   }

--- a/app/controllers/LineageExplorerController.scala
+++ b/app/controllers/LineageExplorerController.scala
@@ -131,6 +131,7 @@ class LineageExplorerController @Inject() (
       }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
     }
   }
+
   def retrieveProjectLineage( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
     logger.debug( "Request to retrieve project lineage for project node with id " + id )
 

--- a/app/controllers/LineageExplorerController.scala
+++ b/app/controllers/LineageExplorerController.scala
@@ -21,6 +21,7 @@ package controllers
 import javax.inject.{ Inject, Singleton }
 
 import authorization.JWTVerifierProvider
+import ch.datascience.graph.Constants
 import ch.datascience.graph.elements.persisted.{ PersistedEdge, PersistedVertex }
 import ch.datascience.graph.elements.persisted.json.{ PersistedEdgeFormat, PersistedVertexFormat }
 import ch.datascience.service.security.ProfileFilterAction
@@ -37,6 +38,7 @@ import play.api.Logger
 import play.api.mvc._
 
 import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
 /**
@@ -59,87 +61,111 @@ class LineageExplorerController @Inject() (
   lazy val logger: Logger = Logger( "application.LineageExplorerController" )
 
   def lineageFromContext( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Find Lineage from deployer with node with id " + id )
+    logger.debug( "Request to retrieve lineage from deployer with node with id " + id )
 
     val g = graphTraversalSource
-    val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "resource:create", "resource:write", "resource:read" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
 
-    val seq = graphExecutionContext.execute {
+    val check_context = g.V( Long.box( id ) ).has( Constants.TypeKey, "deployer:context" )
 
-      for {
-        entry <- t.asScala.toList
-        s = entry.asScala.toMap
-        edges = ensureList[Edge]( s( "edge" ) )
-        vertices = ensureList[Vertex]( s( "node" ) )
-        ( edge, vertex ) <- edges zip vertices
-      } yield ( edge, vertex )
-
+    if ( check_context.isEmpty ) {
+      logger.debug( "Node with id " + id + " is not a context or does not exist, returning NotFound" )
+      Future( NotFound )
     }
+    else {
+      logger.debug( "Returning lineage for node with id " + id )
+      val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "resource:create", "resource:write", "resource:read" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
 
-    Future.traverse( seq.toSet ) {
-      case ( edge, vertex ) =>
+      val seq = graphExecutionContext.execute {
+
         for {
-          e <- edgeReader.read( edge )
-          v <- vertexReader.read( vertex )
+          entry <- t.asScala.toList
+          s = entry.asScala.toMap
+          edges = ensureList[Edge]( s( "edge" ) )
+          vertices = ensureList[Vertex]( s( "node" ) )
+          ( edge, vertex ) <- edges zip vertices
+        } yield ( edge, vertex )
+      }
 
-        } yield ( e, v )
-    }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
-
+      Future.traverse( seq.toSet ) {
+        case ( edge, vertex ) =>
+          for {
+            e <- edgeReader.read( edge )
+            v <- vertexReader.read( vertex )
+          } yield ( e, v )
+      }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
+    }
   }
 
   def lineageFromFile( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Find Lineage from filenode with id " + id )
+    logger.debug( "Request to retrieve lineage from filenode with id " + id )
 
     val g = graphTraversalSource
-    val t = g.V( Long.box( id ) ).inE( "resource:version_of" ).otherV().as( "node" ).repeat( __.bothE( "resource:create", "resource:write", "resource:read", "deployer:launch" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
-    val seq = graphExecutionContext.execute {
+    val check_file = g.V( Long.box( id ) ).has( Constants.TypeKey, "resource:file" )
 
-      for {
-        entry <- t.asScala.toList
-        s = entry.asScala.toMap
-        edges = ensureList[Edge]( s( "edge" ) )
-        vertices = ensureList[Vertex]( s( "node" ) )
-        ( edge, vertex ) <- edges zip vertices
-      } yield ( edge, vertex )
-
+    if ( check_file.isEmpty ) {
+      logger.debug( "Node with id " + id + " is not a file or does not exist, returning NotFound" )
+      Future( NotFound )
     }
+    else {
+      logger.debug( "Returning lineage for file with id " + id )
+      val t = g.V( Long.box( id ) ).inE( "resource:version_of" ).otherV().as( "node" ).repeat( __.bothE( "resource:create", "resource:write", "resource:read", "deployer:launch" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
+      val seq = graphExecutionContext.execute {
 
-    Future.traverse( seq.toSet ) {
-      case ( edge, vertex ) =>
         for {
-          e <- edgeReader.read( edge )
-          v <- vertexReader.read( vertex )
+          entry <- t.asScala.toList
+          s = entry.asScala.toMap
+          edges = ensureList[Edge]( s( "edge" ) )
+          vertices = ensureList[Vertex]( s( "node" ) )
+          ( edge, vertex ) <- edges zip vertices
+        } yield ( edge, vertex )
 
-        } yield ( e, v )
-    }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
+      }
+
+      Future.traverse( seq.toSet ) {
+        case ( edge, vertex ) =>
+          for {
+            e <- edgeReader.read( edge )
+            v <- vertexReader.read( vertex )
+
+          } yield ( e, v )
+      }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
+    }
   }
-
   def retrieveProjectLineage( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
     logger.debug( "Request to retrieve project lineage for project node with id " + id )
 
     val g = graphTraversalSource
-    val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "project:is_part_of", "project:used_by" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
+    val check_project = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
 
-    val seq = graphExecutionContext.execute {
-
-      for {
-        entry <- t.asScala.toList
-        s = entry.asScala.toMap
-        edges = ensureList[Edge]( s( "edge" ) )
-        vertices = ensureList[Vertex]( s( "node" ) )
-        ( edge, vertex ) <- edges zip vertices
-      } yield ( edge, vertex )
-
+    if ( check_project.isEmpty ) {
+      logger.debug( "Node with id " + id + " is not a project or does not exist, returning NotFound" )
+      Future( NotFound )
     }
+    else {
+      logger.debug( "Returning lineage for project with id " + id )
+      val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "project:is_part_of", "project:used_by" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
 
-    Future.traverse( seq.toSet ) {
-      case ( edge, vertex ) =>
+      val seq = graphExecutionContext.execute {
+
         for {
-          e <- edgeReader.read( edge )
-          v <- vertexReader.read( vertex )
+          entry <- t.asScala.toList
+          s = entry.asScala.toMap
+          edges = ensureList[Edge]( s( "edge" ) )
+          vertices = ensureList[Vertex]( s( "node" ) )
+          ( edge, vertex ) <- edges zip vertices
+        } yield ( edge, vertex )
 
-        } yield ( e, v )
-    }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
+      }
+
+      Future.traverse( seq.toSet ) {
+        case ( edge, vertex ) =>
+          for {
+            e <- edgeReader.read( edge )
+            v <- vertexReader.read( vertex )
+
+          } yield ( e, v )
+      }.map( _.map { tuple: ( PersistedEdge, PersistedVertex ) => Map( "edge" -> Json.toJson( tuple._1 ), "vertex" -> Json.toJson( tuple._2 ) ) } ).map( s => Ok( Json.toJson( s ) ) )
+    }
   }
 
   private[this] implicit lazy val persistedVertexFormat: Format[PersistedVertex] = PersistedVertexFormat

--- a/app/controllers/ProjectExplorerController.scala
+++ b/app/controllers/ProjectExplorerController.scala
@@ -109,9 +109,9 @@ class ProjectExplorerController @Inject() (
     val availableResources = Set( "file", "bucket", "context", "execution" )
 
     val g = graphTraversalSource
-    val check_file = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
+    val check_project = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
 
-    if ( check_file.isEmpty ) {
+    if ( check_project.isEmpty ) {
       logger.debug( "Node with id " + id + " is not a project node or does not exist, returning NotFound" )
       Future( NotFound )
     }
@@ -141,10 +141,10 @@ class ProjectExplorerController @Inject() (
 
       future.map {
         case x :: xs =>
-          logger.debug("Returning requested resouces")
+          logger.debug( "Returning requested resouces" )
           Ok( Json.toJson( x :: xs ) )
-        case _       =>
-          logger.debug("No resources found, returning NotFound")
+        case _ =>
+          logger.debug( "No resources found, returning NotFound" )
           NotFound
       }
     }

--- a/app/controllers/ProjectExplorerController.scala
+++ b/app/controllers/ProjectExplorerController.scala
@@ -22,7 +22,7 @@ import javax.inject.{ Inject, Singleton }
 
 import authorization.JWTVerifierProvider
 import ch.datascience.graph.Constants
-import ch.datascience.graph.elements.persisted.PersistedVertex
+import ch.datascience.graph.elements.persisted.{ PersistedEdge, PersistedVertex }
 import ch.datascience.graph.elements.persisted.json.{ PersistedEdgeFormat, PersistedVertexFormat }
 import ch.datascience.service.security.ProfileFilterAction
 import ch.datascience.service.utils.persistence.graph.{ GraphExecutionContextProvider, JanusGraphTraversalSourceProvider }
@@ -31,7 +31,7 @@ import ch.datascience.service.utils.{ ControllerWithBodyParseJson, ControllerWit
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json.Json
+import play.api.libs.json.{ Format, Json }
 import play.api.libs.ws.WSClient
 import play.api.Logger
 import play.api.mvc._
@@ -90,6 +90,7 @@ class ProjectExplorerController @Inject() (
 
   def retrieveProjectMetadata( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
     logger.debug( "Request to retrieve project metadata for project node with id " + id )
+
     val g = graphTraversalSource
     val t = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
 
@@ -108,29 +109,44 @@ class ProjectExplorerController @Inject() (
     val availableResources = Set( "file", "bucket", "context", "execution" )
 
     val g = graphTraversalSource
+    val check_file = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
 
-    val t: GraphTraversal[Vertex, Vertex] = resource match {
-      case None => {
-        logger.debug( "Requested all resources" )
-        g.V( Long.box( id ) ).inE( "project:is_part_of" ).otherV()
+    if ( check_file.isEmpty ) {
+      logger.debug( "Node with id " + id + " is not a project node or does not exist, returning NotFound" )
+      Future( NotFound )
+    }
+
+    else {
+      val t: GraphTraversal[Vertex, Vertex] = resource match {
+        case None =>
+          logger.debug( "Requested all resources" )
+          g.V( Long.box( id ) ).inE( "project:is_part_of" ).otherV()
+
+        case Some( x ) =>
+          if ( availableResources.contains( x ) ) {
+            logger.debug( "Requested resource " + x )
+            g.V( Long.box( id ) ).inE( "project:is_part_of" ).otherV().has( Constants.TypeKey, stringToKey( x ) )
+
+          }
+          else {
+            logger.debug( "Type " + x + " not supported" )
+            throw new UnsupportedOperationException( "Type not supported" )
+          }
       }
-      case Some( x ) =>
-        if ( availableResources.contains( x ) ) {
-          logger.debug( "Requested resource " + x )
-          g.V( Long.box( id ) ).inE( "project:is_part_of" ).otherV().has( Constants.TypeKey, stringToKey( x ) )
 
-        }
-        else throw new UnsupportedOperationException( "Type not supported" )
-    }
+      val future: Future[List[PersistedVertex]] = graphExecutionContext.execute {
+        Future.sequence( t.toIterable.map( v =>
+          vertexReader.read( v ) ).toList )
+      }
 
-    val future: Future[List[PersistedVertex]] = graphExecutionContext.execute {
-      Future.sequence( t.toIterable.map( v =>
-        vertexReader.read( v ) ).toList )
-    }
-
-    future.map {
-      case x :: xs => Ok( Json.toJson( x :: xs ) )
-      case _       => NotFound
+      future.map {
+        case x :: xs =>
+          logger.debug("Returning requested resouces")
+          Ok( Json.toJson( x :: xs ) )
+        case _       =>
+          logger.debug("No resources found, returning NotFound")
+          NotFound
+      }
     }
   }
 
@@ -144,6 +160,6 @@ class ProjectExplorerController @Inject() (
     }
   }
 
-  private[this] implicit lazy val persistedVertexFormat = PersistedVertexFormat
-  private[this] implicit lazy val persistedEdgeFormat = PersistedEdgeFormat
+  private[this] implicit lazy val persistedVertexFormat: Format[PersistedVertex] = PersistedVertexFormat
+  private[this] implicit lazy val persistedEdgeFormat: Format[PersistedEdge] = PersistedEdgeFormat
 }

--- a/app/controllers/StorageExplorerController.scala
+++ b/app/controllers/StorageExplorerController.scala
@@ -139,8 +139,12 @@ class StorageExplorerController @Inject() (
         Seq.empty
       }
     } ).map( a => a.toList match {
-      case x :: xs => Ok( Json.toJson( ( x :: xs ).toMap ) )
-      case _       => NotFound
+      case x :: xs =>
+        logger.debug( "Returning metadata for file " + path + " in bucket with id " + id )
+        Ok( Json.toJson( ( x :: xs ).toMap ) )
+      case _ =>
+        logger.debug( "No metadata found for file " + path + " in bucket with id " + id + " returning NotFound" )
+        NotFound
     } )
   }
 
@@ -171,8 +175,13 @@ class StorageExplorerController @Inject() (
       }
 
     } ).map( a => a.toList match {
-      case x :: xs => Ok( Json.toJson( ( x :: xs ).toMap ) )
-      case _       => NotFound
+      case x :: xs =>
+        logger.debug( "Returning metadata for file node with id " + id )
+        Ok( Json.toJson( ( x :: xs ).toMap ) )
+      case _ =>
+        // This should not happen
+        logger.debug( "No metadata found, returning NotFound" )
+        NotFound
     } )
   }
 

--- a/test/controllers/GenericExplorerControllerSpec.scala
+++ b/test/controllers/GenericExplorerControllerSpec.scala
@@ -185,7 +185,7 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The property search controller" should {
-    "be able to an empty list if no nodes were found with that property" in {
+    "be able to return an empty list if no nodes were found with that property" in {
 
       val prop = "coffee"
 

--- a/test/controllers/GenericExplorerControllerSpec.scala
+++ b/test/controllers/GenericExplorerControllerSpec.scala
@@ -185,7 +185,7 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The property search controller" should {
-    "be able to return a NotFound if no nodes were found" in {
+    "be able to an empty list if no nodes were found with that property" in {
 
       val prop = "coffee"
 

--- a/test/controllers/GenericExplorerControllerSpec.scala
+++ b/test/controllers/GenericExplorerControllerSpec.scala
@@ -135,26 +135,21 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The edge retrieval of a node controller" should {
-    "return a 404 if a node with id exists but has no edges (somehow)" in {
+    "return an empty list if a node with id exists but has no edges (somehow)" in {
 
       val nodeId = g.V().has( "single", "node" ).asScala.toList.head.id
 
       val result = genericController.retrieveNodeEdges( nodeId.toString.toLong ).apply( fakerequest )
+      val content = contentAsJson( result ).as[List[PersistedEdge]]
 
-      val resultStatus = result.map( x => x.header.status )
-
-      for ( status <- resultStatus ) {
-        status.toString mustBe "404"
-      }
+      content.length mustBe 0
     }
   }
 
   "The edge retrieval of a node controller" should {
     "return a 404 NotFound if a node does not exist in the graph" in {
 
-      val nodeId = g.V().has( "single", "node" ).asScala.toList.head.id
-
-      val result = genericController.retrieveNodeEdges( nodeId.toString.toLong ).apply( fakerequest )
+      val result = genericController.retrieveNodeEdges( "0".toLong ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
 
       for ( status <- resultStatus ) {
@@ -195,11 +190,9 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
       val prop = "coffee"
 
       val result = genericController.retrieveNodesWithProperty( prop ).apply( fakerequest )
-      val resultStatus = result.map( x => x.header.status )
 
-      for ( status <- resultStatus ) {
-        status.toString mustBe "404"
-      }
+      val content = contentAsJson( result ).as[List[PersistedVertex]]
+      content.length mustBe 0
     }
   }
 
@@ -245,14 +238,14 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The value search controller" should {
-    "return an empty list of the property does not exist" in {
+    "return an empty of the property does not exist in the graph" in {
 
       val prop = "coffee"
 
       val result = genericController.getValuesForProperty( prop ).apply( fakerequest )
       val content = contentAsJson( result ).as[List[String]]
-
       content.length mustBe 0
+
     }
   }
 
@@ -274,33 +267,28 @@ class GenericExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The property value controller " should {
-    "return a 404 if that property is not found" in {
+    "return an empty list if the property or value is not found" in {
 
       val prop = "importance"
       val value = "urgent"
 
       val result = genericController.retrieveNodePropertyAndValue( prop, value ).apply( fakerequest )
-      val resultStatus = result.map( x => x.header.status )
-
-      for ( status <- resultStatus ) {
-        status.toString mustBe "404"
-      }
+      val content = contentAsJson( result ).as[List[PersistedVertex]]
+      content.length mustBe 0
     }
   }
 
   "The property value controller " should {
-    "return a a 404 if a value for that property is not found" in {
+    "return an empty list if a value for that property is not found" in {
       val prop = "coffee"
       val value = "strong"
 
       val result = genericController.retrieveNodePropertyAndValue( prop, value ).apply( fakerequest )
-      val resultStatus = result.map( x => x.header.status )
-
-      for ( status <- resultStatus ) {
-        status.toString mustBe "404"
-      }
+      val content = contentAsJson( result ).as[List[PersistedVertex]]
+      content.length mustBe 0
     }
   }
+
   "The property value controller " should {
     "return a proper list if the value is not a string" in {
       val prop = "system:creation_time"

--- a/test/controllers/LineageExplorerControllerSpec.scala
+++ b/test/controllers/LineageExplorerControllerSpec.scala
@@ -95,7 +95,7 @@ class LineageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The lineage from context controller" should {
-    "return a 404 NotFound if the node does not exist" in {
+    "return a 404 NotFound if the id of the node is not a deployernode" in {
       val id = g.V().has( Constants.TypeKey, "resource:file" ).asScala.toList.head.id
 
       val result = lineageController.lineageFromContext( id.toString.toLong ).apply( fakerequest )
@@ -108,7 +108,7 @@ class LineageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The lineage from context controller" should {
-    "return a 404 NotFound if the id of the node is not a deployernode" in {
+    "return a 404 NotFound if the node does not exist" in {
       val result = lineageController.lineageFromContext( 0L ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
 
@@ -119,7 +119,7 @@ class LineageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The lineage from file controller" should {
-    "return the lineage from a file " in {
+    "return the lineage from a file" in {
 
       val fileId = g.V().has( Constants.TypeKey, "resource:file" ).asScala.toList.head.id
       val nodes = g.V( fileId ).inE( "resource:version_of" ).otherV().as( "node" ).repeat( __.bothE( "resource:create", "resource:write", "resource:read", "deployer:launch" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" ).asScala.toList
@@ -135,7 +135,7 @@ class LineageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The lineage from file controller" should {
-    "return a NotFound if the node does not exist " in {
+    "return a NotFound if the node does not exist" in {
       val result = lineageController.lineageFromFile( 0L ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
 
@@ -146,7 +146,7 @@ class LineageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The lineage from file controller" should {
-    "return a NotFound if the node is not a file " in {
+    "return a NotFound if the node is not a file" in {
       val id = g.V().has( Constants.TypeKey, "deployer:context" ).asScala.toList.head.id
 
       val result = lineageController.lineageFromFile( id.toString.toLong ).apply( fakerequest )

--- a/test/controllers/ProjectExplorerControllerSpec.scala
+++ b/test/controllers/ProjectExplorerControllerSpec.scala
@@ -119,6 +119,31 @@ class ProjectExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
     }
   }
 
+  "The project metadata query" should {
+    "return 404 if the requested projectnode is not a project resource" in {
+      val nodeId = g.V().has( Constants.TypeKey, "resource:file" ).asScala.toList.head.id
+
+      val result = projectController.retrieveProjectMetadata( nodeId.toString.toLong ).apply( fakerequest )
+
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
+  "The project metadata query" should {
+    "return 404 if the requested projectnode does not exist" in {
+      val nodeId = 3
+
+      val result = projectController.retrieveProjectMetadata( nodeId.toString.toLong ).apply( fakerequest )
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
   "The project resources query" should {
     "return all buckets in a project if resource=bucket" in {
       val projectId = g.V().has( Constants.TypeKey, "project:project" ).asScala.toList.head.id()
@@ -144,7 +169,7 @@ class ProjectExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The project resources query" should {
-    "return a 404 if an incorrect project id is given" in {
+    "return a 404 if an node is not a project" in {
       val fileId = g.V().has( Constants.TypeKey, "resource:file" ).asScala.toList.head.id()
 
       val result = projectController.retrieveProjectResources( fileId.toString.toLong, None ).apply( fakerequest )

--- a/test/controllers/StorageExplorerControllerSpec.scala
+++ b/test/controllers/StorageExplorerControllerSpec.scala
@@ -144,7 +144,9 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
 
   "The bucket metadata exploration controller" should {
     "return 404 NotFound if the node is not a bucket" in {
-      val result = explorerController.bucketMetadata( "32".toLong ).apply( fakerequest )
+      val id = g.V().has( Constants.TypeKey, "resource:file" ).asScala.toList.head.id
+
+      val result = explorerController.bucketMetadata( id.toString.toLong ).apply( fakerequest )
 
       val resultStatus = result.map( x => x.header.status )
 
@@ -157,8 +159,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   "The bucket metadata exploration controller" should {
     "return a 404 NotFound if the bucket does not exist" in {
 
-      val result = explorerController.bucketMetadata( "32".toString.toLong ).apply( fakerequest )
-
+      val result = explorerController.bucketMetadata( "32".toLong ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
 
       for ( status <- resultStatus ) {
@@ -201,6 +202,31 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
     }
   }
 
+  "The file exploration controller" should {
+    "should return 404 if the requested node is not a bucket" in {
+      val id = g.V().has( Constants.TypeKey, "resource:file_version" ).asScala.toList.head.id
+
+      val result = explorerController.fileList( id.toString.toLong ).apply( fakerequest )
+
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
+  "The file exploration controller" should {
+    "should return 404 if the bucket does not exist" in {
+
+      val result = explorerController.fileList( "5".toLong ).apply( fakerequest )
+
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
   "The file version exploration controller" should {
     "return all versions of a file " in {
 
@@ -216,6 +242,30 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
 
       content.length mustBe graphVersions.length
       contentTimeStamps.toSet mustBe graphVersionTimeStamps.toSet
+    }
+  }
+
+  "The file version controller" should {
+    "return a NotFound if the requested node does not exist" in {
+
+      val result = explorerController.retrievefileVersions( "3".toLong ).apply( fakerequest )
+
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
+  "The file version controller" should {
+    "return a NotFound if the requested node is not a file" in {
+      val id = g.V().has( Constants.TypeKey, "resource:bucket" ).asScala.toList.head.id
+      val result = explorerController.retrievefileVersions( id.toString.toLong ).apply( fakerequest )
+
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
     }
   }
 
@@ -257,6 +307,29 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
     }
   }
 
+  "The file meta data exploration controller" should {
+    "should return 404 NotFound if the node is not a bucket " in {
+
+      val id = g.V().has( Constants.TypeKey, "resource:bucket" ).asScala.toList.head.id
+      val result = explorerController.fileMetadata( id.toString.toLong ).apply( fakerequest )
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
+  "The file meta data exploration controller" should {
+    "should return 404 NotFound if the file does not exist " in {
+
+      val result = explorerController.fileMetadata( "3".toLong ).apply( fakerequest )
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
   "The file meta data from path exploration controller" should {
     "return all metadata of a file " in {
 
@@ -277,6 +350,32 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
 
       graphBucketMetaData( 0 ) mustBe bucketMetaValues( 0 )
       graphBucketMetaData( 1 ) mustBe bucketMetaValues( 1 )
+    }
+  }
+
+  "The file meta data from path exploration controller" should {
+    "should return 404 NotFound if the filepath does not exist " in {
+
+      val bucketId = g.V().out( "resource:has_location" ).out( "resource:stored_in" ).asScala.toList.head
+      val result = explorerController.fileMetadatafromPath( bucketId.id.toString.toLong, "fake_path" ).apply( fakerequest )
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
+    }
+  }
+
+  "The file meta data from path exploration controller" should {
+    "should return 404 NotFound if the bucket does not exist " in {
+
+      val graphFile = g.V().in( "resource:stored_in" ).in( "resource:has_location" ).has( Constants.TypeKey, "resource:file" ).asScala.toList.head
+      val path = graphFile.values[String]( "resource:file_name" ).asScala.toList.head
+
+      val result = explorerController.fileMetadatafromPath( "3".toLong, path ).apply( fakerequest )
+      val resultStatus = result.map( x => x.header.status )
+      for ( status <- resultStatus ) {
+        status.toString mustBe "404"
+      }
     }
   }
 

--- a/test/controllers/StorageExplorerControllerSpec.scala
+++ b/test/controllers/StorageExplorerControllerSpec.scala
@@ -308,7 +308,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file meta data exploration controller" should {
-    "should return 404 NotFound if the node is not a file " in {
+    "return 404 NotFound if the node is not a file " in {
 
       val id = g.V().has( Constants.TypeKey, "resource:bucket" ).asScala.toList.head.id
       val result = explorerController.fileMetadata( id.toString.toLong ).apply( fakerequest )
@@ -320,7 +320,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file meta data exploration controller" should {
-    "should return 404 NotFound if the file does not exist " in {
+    "return 404 NotFound if the file does not exist " in {
 
       val result = explorerController.fileMetadata( "3".toLong ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
@@ -354,7 +354,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file meta data from path exploration controller" should {
-    "should return 404 NotFound if the filepath does not exist " in {
+    "return 404 NotFound if the filepath does not exist " in {
 
       val bucketId = g.V().out( "resource:has_location" ).out( "resource:stored_in" ).asScala.toList.head
       val result = explorerController.fileMetadatafromPath( bucketId.id.toString.toLong, "fake_path" ).apply( fakerequest )
@@ -366,7 +366,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file meta data from path exploration controller" should {
-    "should return 404 NotFound if the bucket does not exist " in {
+    "return 404 NotFound if the bucket does not exist " in {
 
       val graphFile = g.V().in( "resource:stored_in" ).in( "resource:has_location" ).has( Constants.TypeKey, "resource:file" ).asScala.toList.head
       val path = graphFile.values[String]( "resource:file_name" ).asScala.toList.head

--- a/test/controllers/StorageExplorerControllerSpec.scala
+++ b/test/controllers/StorageExplorerControllerSpec.scala
@@ -157,7 +157,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The bucket metadata exploration controller" should {
-    "return a 404 NotFound if the bucket does not exist" in {
+    "return a 404 NotFound if the node does not exist" in {
 
       val result = explorerController.bucketMetadata( "32".toLong ).apply( fakerequest )
       val resultStatus = result.map( x => x.header.status )
@@ -216,7 +216,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file exploration controller" should {
-    "should return 404 if the bucket does not exist" in {
+    "should return 404 if the node does not exist" in {
 
       val result = explorerController.fileList( "5".toLong ).apply( fakerequest )
 
@@ -308,7 +308,7 @@ class StorageExplorerControllerSpec extends PlaySpec with OneAppPerSuite with Mo
   }
 
   "The file meta data exploration controller" should {
-    "should return 404 NotFound if the node is not a bucket " in {
+    "should return 404 NotFound if the node is not a file " in {
 
       val id = g.V().has( Constants.TypeKey, "resource:bucket" ).asScala.toList.head.id
       val result = explorerController.fileMetadata( id.toString.toLong ).apply( fakerequest )


### PR DESCRIPTION
Resolving issue #44 : I added several "catches" and added more logging. Here and there it is not clear what the best return would be. E.g. In the generic explorer when it comes to values/property searches. As they are more "free" in my perspective you can return an empty list. If there are some things which someone think could be improved by less/more NotFounds, let me know.