### PR TITLE
Api cleanup

### DIFF
--- a/app/controllers/GenericExplorerController.scala
+++ b/app/controllers/GenericExplorerController.scala
@@ -84,10 +84,10 @@ class GenericExplorerController @Inject() (
     future.map( i => Ok( Json.toJson( i ) ) )
   }
 
-  def retrieveNodeMetaData( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Request to retrieve data of node with id " + id )
+  def retrieveNodeMetaData( nodeid: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
+    logger.debug( "Request to retrieve data of node with id " + nodeid )
     val g = graphTraversalSource
-    val t = g.V( Long.box( id ) )
+    val t = g.V( Long.box( nodeid ) )
 
     val future: Future[Option[PersistedVertex]] = graphExecutionContext.execute {
       if ( t.hasNext ) {
@@ -99,27 +99,27 @@ class GenericExplorerController @Inject() (
     }
     future.map {
       case Some( vertex ) =>
-        logger.debug( "Returning metadata for node with id" + id )
+        logger.debug( "Returning metadata for node with id" + nodeid )
         Ok( Json.toJson( vertex )( PersistedVertexFormat ) )
       case None =>
-        logger.debug( "Node with id " + id + " does not exist" )
+        logger.debug( "Node with id " + nodeid + " does not exist" )
         NotFound
     }
   }
 
   //Get all edges belonging to a node
-  def retrieveNodeEdges( id: Long ) = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Request to ingoing and outgoing edges of node with id " + id )
+  def retrieveNodeEdges( nodeid: Long ) = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
+    logger.debug( "Request to ingoing and outgoing edges of node with id " + nodeid )
     val g = graphTraversalSource
 
-    val check_node = g.V( Long.box( id ) )
+    val check_node = g.V( Long.box( nodeid ) )
     // Discerning between a node with no edges and a node that does not exist
     if ( check_node.isEmpty ) {
-      logger.debug( "Node with id " + id + " does not exist, returning NotFound" )
+      logger.debug( "Node with id " + nodeid + " does not exist, returning NotFound" )
       Future( NotFound )
     }
     else {
-      val t = g.V( Long.box( id ) ).bothE()
+      val t = g.V( Long.box( nodeid ) ).bothE()
       val future: Future[List[PersistedEdge]] = {
         if ( t.hasNext ) {
           Future.sequence(
@@ -131,10 +131,10 @@ class GenericExplorerController @Inject() (
       }
       future.map {
         case x :: xs =>
-          logger.debug( "Returning edges for node with id " + id )
+          logger.debug( "Returning edges for node with id " + nodeid )
           Ok( Json.toJson( x :: xs ) )
         case _ =>
-          logger.debug( "Node with id " + id + " has no edges" )
+          logger.debug( "Node with id " + nodeid + " has no edges" )
           Ok( Json.toJson( List.empty[PersistedEdge] ) )
       }
     }

--- a/app/controllers/LineageExplorerController.scala
+++ b/app/controllers/LineageExplorerController.scala
@@ -60,20 +60,20 @@ class LineageExplorerController @Inject() (
 
   lazy val logger: Logger = Logger( "application.LineageExplorerController" )
 
-  def lineageFromContext( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Request to retrieve lineage from deployer with node with id " + id )
+  def lineageFromContext( contextid: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
+    logger.debug( "Request to retrieve lineage from deployer with node with id " + contextid )
 
     val g = graphTraversalSource
 
-    val check_context = g.V( Long.box( id ) ).has( Constants.TypeKey, "deployer:context" )
+    val check_context = g.V( Long.box( contextid ) ).has( Constants.TypeKey, "deployer:context" )
 
     if ( check_context.isEmpty ) {
-      logger.debug( "Node with id " + id + " is not a context or does not exist, returning NotFound" )
+      logger.debug( "Node with id " + contextid + " is not a context or does not exist, returning NotFound" )
       Future( NotFound )
     }
     else {
-      logger.debug( "Returning lineage for node with id " + id )
-      val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "resource:create", "resource:write", "resource:read" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
+      logger.debug( "Returning lineage for node with id " + contextid )
+      val t = g.V( Long.box( contextid ) ).repeat( __.bothE( "deployer:launch", "resource:create", "resource:write", "resource:read" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
 
       val seq = graphExecutionContext.execute {
 
@@ -96,19 +96,19 @@ class LineageExplorerController @Inject() (
     }
   }
 
-  def lineageFromFile( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Request to retrieve lineage from filenode with id " + id )
+  def lineageFromFile( fileid: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
+    logger.debug( "Request to retrieve lineage from filenode with id " + fileid )
 
     val g = graphTraversalSource
-    val check_file = g.V( Long.box( id ) ).has( Constants.TypeKey, "resource:file" )
+    val check_file = g.V( Long.box( fileid ) ).has( Constants.TypeKey, "resource:file" )
 
     if ( check_file.isEmpty ) {
-      logger.debug( "Node with id " + id + " is not a file or does not exist, returning NotFound" )
+      logger.debug( "Node with id " + fileid + " is not a file or does not exist, returning NotFound" )
       Future( NotFound )
     }
     else {
-      logger.debug( "Returning lineage for file with id " + id )
-      val t = g.V( Long.box( id ) ).inE( "resource:version_of" ).otherV().as( "node" ).repeat( __.bothE( "resource:create", "resource:write", "resource:read", "deployer:launch" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
+      logger.debug( "Returning lineage for file with id " + fileid )
+      val t = g.V( Long.box( fileid ) ).inE( "resource:version_of" ).otherV().as( "node" ).repeat( __.bothE( "resource:create", "resource:write", "resource:read", "deployer:launch" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
       val seq = graphExecutionContext.execute {
 
         for {
@@ -132,19 +132,19 @@ class LineageExplorerController @Inject() (
     }
   }
 
-  def retrieveProjectLineage( id: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
-    logger.debug( "Request to retrieve project lineage for project node with id " + id )
+  def retrieveProjectLineage( projectid: Long ): Action[AnyContent] = ProfileFilterAction( jwtVerifier.get ).async { implicit request =>
+    logger.debug( "Request to retrieve project lineage for project node with id " + projectid )
 
     val g = graphTraversalSource
-    val check_project = g.V( Long.box( id ) ).has( Constants.TypeKey, "project:project" )
+    val check_project = g.V( Long.box( projectid ) ).has( Constants.TypeKey, "project:project" )
 
     if ( check_project.isEmpty ) {
-      logger.debug( "Node with id " + id + " is not a project or does not exist, returning NotFound" )
+      logger.debug( "Node with id " + projectid + " is not a project or does not exist, returning NotFound" )
       Future( NotFound )
     }
     else {
-      logger.debug( "Returning lineage for project with id " + id )
-      val t = g.V( Long.box( id ) ).repeat( __.bothE( "deployer:launch", "project:is_part_of", "project:used_by" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
+      logger.debug( "Returning lineage for project with id " + projectid )
+      val t = g.V( Long.box( projectid ) ).repeat( __.bothE( "deployer:launch", "project:is_part_of", "project:used_by" ).dedup().as( "edge" ).otherV().as( "node" ) ).emit().simplePath().select[java.lang.Object]( "edge", "node" )
 
       val seq = graphExecutionContext.execute {
 

--- a/conf/routes
+++ b/conf/routes
@@ -5,28 +5,27 @@
 
 # Api spec
 GET      /swagger.json                            controllers.SwaggerController.getSwagger
-
-GET      /storage/bucket                          controllers.StorageExplorerController.bucketList
-GET      /storage/file/:id                        controllers.StorageExplorerController.fileMetadata(id: Long)
-GET      /storage/bucket/:id/files                controllers.StorageExplorerController.fileList(id: Long)
-GET      /storage/bucket/:id                      controllers.StorageExplorerController.bucketMetadata(id: Long)
-GET      /storage/bucket/:id/files/:path          controllers.StorageExplorerController.fileMetadatafromPath(id: Long, path: String)
-GET      /storage/file/:id/versions               controllers.StorageExplorerController.retrievefileVersions( id: Long )
-GET      /storage/file/timestamps/:date1/:date2   controllers.StorageExplorerController.retrieveFilesDate( date1: Long, date2: Long )
+GET      /storage/buckets                         controllers.StorageExplorerController.bucketList
+GET      /storage/files/:fileid                   controllers.StorageExplorerController.fileMetadata(fileid: Long)
+GET      /storage/buckets/:bucketid/files         controllers.StorageExplorerController.fileList(bucketid: Long)
+GET      /storage/buckets/:bucketid               controllers.StorageExplorerController.bucketMetadata(bucketid: Long)
+GET      /storage/buckets/:bucketid/files/:path   controllers.StorageExplorerController.fileMetadatafromPath(bucketid: Long, path: String)
+GET      /storage/files/:fileid/versions          controllers.StorageExplorerController.retrievefileVersions( fileid: Long )
+GET      /storage/files/timestamps                controllers.StorageExplorerController.retrieveFilesDate( date1: Option[Long], date2: Option[Long] )
 GET      /storage                                 controllers.StorageExplorerController.retrieveByUserName(userId: String)
 
-GET      /graph/full                              controllers.GenericExplorerController.retrieveGraphSubset
-GET      /graph/node/:id                          controllers.GenericExplorerController.retrieveNodeMetaData( id: Long )
-GET      /graph/node/:id/edges                    controllers.GenericExplorerController.retrieveNodeEdges( id: Long )
+GET      /graph                                   controllers.GenericExplorerController.retrieveGraphSubset
+GET      /graph/nodes/:nodeid                     controllers.GenericExplorerController.retrieveNodeMetaData( nodeid: Long )
+GET      /graph/nodes/:nodeid/edges               controllers.GenericExplorerController.retrieveNodeEdges( nodeid: Long )
 GET      /graph/nodes/:prop                       controllers.GenericExplorerController.retrieveNodesWithProperty( prop: String )
 GET      /graph/:prop/values                      controllers.GenericExplorerController.getValuesForProperty( prop: String )
 GET      /graph/nodes/:prop/:value                controllers.GenericExplorerController.retrieveNodePropertyAndValue( prop: String, value: String)
 
-GET      /lineage/context/:id                     controllers.LineageExplorerController.lineageFromContext(id: Long)
-GET      /lineage/file/:id                        controllers.LineageExplorerController.lineageFromFile(id: Long)
-GET      /lineage/project/:id/                    controllers.LineageExplorerController.retrieveProjectLineage(id: Long)
+GET      /lineage/contexts/:contextid             controllers.LineageExplorerController.lineageFromContext(contextid: Long)
+GET      /lineage/files/:fileid                   controllers.LineageExplorerController.lineageFromFile(fileid: Long)
+GET      /lineage/projects/:projectid             controllers.LineageExplorerController.retrieveProjectLineage(projectid: Long)
 
 GET      /projects                                controllers.ProjectExplorerController.retrieveProjects
-GET      /projects/user                           controllers.ProjectExplorerController.retrieveProjectByUserName(userId: Option[String] )
-GET      /projects/:id                            controllers.ProjectExplorerController.retrieveProjectMetadata( id: Long )
-GET      /projects/:id/resources                  controllers.ProjectExplorerController.retrieveProjectResources( id: Long, resource: Option[String] )
+GET      /projects/users                          controllers.ProjectExplorerController.retrieveProjectByUserName(userid: Option[String] )
+GET      /projects/:projectid                     controllers.ProjectExplorerController.retrieveProjectMetadata( projectid: Long )
+GET      /projects/:projectid/resources           controllers.ProjectExplorerController.retrieveProjectResources( projectid: Long, resource: Option[String] )

--- a/swagger.yml
+++ b/swagger.yml
@@ -22,35 +22,26 @@ tags:
 - name: 'Explorer-Storage'
   description: 'Storage explorer'
 paths:
-  /storage/bucket/{bucketId}:
+ /storage/buckets:
     get:
       tags:
       - 'Explorer-Storage'
-      summary: 'Bucket metadata'
-      description: 'Access bucket metadata'
-      parameters:
-      - name: bucketId
-        in: path
-        description: 'Bucket graph id'
-        required: true
-        type: integer
-        format: int64
+      summary: 'Bucket list'
+      description: 'List all available buckets'
       responses:
         200:
           description: 'Ok'
-        404:
-          description: 'Bucket not found'
       security:
       - token_auth:
         - 'profile'
-  /storage/file/{fileId}:
+  /storage/files/{fileid}:
     get:
       tags:
       - 'Explorer-Storage'
       summary: 'File metadata'
       description: 'Access file metadata'
       parameters:
-      - name: fileId
+      - name: fileid
         in: path
         description: 'File graph id'
         required: true
@@ -64,14 +55,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /storage/bucket/{bucketId}/files:
+  /storage/buckets/{bucketid}/files:
     get:
       tags:
       - 'Explorer-Storage'
       summary: 'Bucket files'
       description: 'List all files in a bucket'
       parameters:
-      - name: bucketId
+      - name: bucketid
         in: path
         description: 'Bucket graph id'
         required: true
@@ -85,26 +76,35 @@ paths:
       security:
       - token_auth:
          - 'profile'
-  /storage/bucket:
+  /storage/buckets/{bucketid}:
     get:
       tags:
       - 'Explorer-Storage'
-      summary: 'Bucket list'
-      description: 'List all available buckets'
+      summary: 'Bucket metadata'
+      description: 'Access bucket metadata'
+      parameters:
+      - name: bucketid
+        in: path
+        description: 'Bucket graph id'
+        required: true
+        type: integer
+        format: int64
       responses:
         200:
           description: 'Ok'
+        404:
+          description: 'Bucket not found'
       security:
       - token_auth:
         - 'profile'
-  /storage/bucket/{bucketId}/files/{path}:
+  /storage/buckets/{bucketid}/files/{path}:
     get:
       tags:
         - 'Explorer-Storage'
       summary: 'Access file metadata'
       description: 'File metadata from bucket and path'
       parameters:
-      - name: bucketId
+      - name: bucketid
         in: path
         description: 'Bucket graph id'
         required: true
@@ -123,14 +123,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /storage/file/{fileId}/versions:
+  /storage/files/{fileid}/versions:
     get:
       tags:
         - 'Explorer-Storage'
       summary: 'File versions'
       description:  'Get all version from a file'
       parameters:
-      - name: fileId
+      - name: fileid
         in: path
         description: 'File graph id'
         required: true
@@ -144,7 +144,7 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /storage/file/timestamps/{date1}/{date2}:
+  /storage/files/timestamps:
     get:
       tags:
          - 'Explorer-Storage'
@@ -154,13 +154,13 @@ paths:
       - name: date1
         in: path
         description: 'Lower timestamp'
-        required: true
+        required: false
         type: integer
         format: int64
       - name: date2
         in: path
         description: 'Upper timestamp'
-        required: true
+        required: false
         type: integer
         format: int64
       responses:
@@ -187,7 +187,7 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /graph/full:
+  /graph:
     get:
       tags:
          - 'Explorer-Graph'
@@ -199,7 +199,7 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /graph/node/{nodeid}:
+  /graph/nodes/{nodeid}:
     get:
       tags:
          - 'Explorer-Graph'
@@ -218,7 +218,7 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /graph/node/{nodeid}/edges:
+  /graph/nodes/{nodeid}/edges:
     get:
       tags:
          - 'Explorer-Graph'
@@ -296,16 +296,16 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /lineage/context/{contextId}:
+  /lineage/contexts/{contextid}:
     get:
       tags:
          - 'Explorer-Lineage'
       summary: 'Lineage from context'
       description:  'Lineage from an execution context '
       parameters:
-      - name: contextId
+      - name: contextid
         in: path
-        description: 'context node id'
+        description: 'Context node id'
         required: true
         type: integer
         format: int64
@@ -315,14 +315,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /lineage/file/{fileId}:
+  /lineage/files/{fileid}:
     get:
       tags:
          - 'Explorer-Lineage'
       summary: 'Lineage from file'
       description:  'Lineage from a file '
       parameters:
-      - name: fileId
+      - name: fileid
         in: path
         description: 'file node id'
         required: true
@@ -334,14 +334,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /lineage/project/{projectNodeId}:
+  /lineage/projects/{projectid}:
     get:
       tags:
          - 'Explorer-Lineage'
       summary: 'Get project lineage'
       description:  'Get project lineage for projectnode with projectNodeId'
       parameters:
-      - name: projectNodeId
+      - name: projectid
         in: path
         description: 'Project node id'
         required: true
@@ -364,14 +364,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /projects/user:
+  /projects/users:
     get:
       tags:
          - 'Explorer-Projects'
       summary: 'List user project nodes'
-      description:  'Get all project nodes of a user with userId (limited)'
+      description:  'Get all project nodes of a user with userid (limited)'
       parameters:
-      - name: userId
+      - name: userid
         in: query
         description: 'User id'
         required: false
@@ -382,14 +382,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /projects/{projectNodeId}:
+  /projects/{projectid}:
     get:
       tags:
          - 'Explorer-Projects'
       summary: 'Get metadata'
       description:  'Get metadatea for projectnode with projectNodeId'
       parameters:
-      - name: projectNodeId
+      - name: projectid
         in: path
         description: 'Project node id'
         required: true
@@ -400,14 +400,14 @@ paths:
       security:
       - token_auth:
         - 'profile'
-  /projects/{projectNodeId}/resources:
+  /projects/{projectid}/resources:
     get:
       tags:
          - 'Explorer-Projects'
       summary: 'Get project resources'
       description:  'Get resource from project with projectNodeId. Resource should be a type that is present in the graph, like bucket, file, execution or context'
       parameters:
-      - name: projectNodeId
+      - name: projectid
         in: path
         description: 'Project node id'
         required: true
@@ -415,7 +415,7 @@ paths:
       - name: resources
         in: query
         description: 'Type of resource requested'
-        required: true
+        required: false
         type: string
       responses:
         200:


### PR DESCRIPTION
Updates routes based on comments mentioned in issue #11 Added plurals for collections and removed superfluous items, e.g.   /storage/file/:id -> /storage/file?fileid

Added standard values for version search so that date1 and date2 are optional. 